### PR TITLE
Add css class to yellowcube column on product grid

### DIFF
--- a/Ui/Component/Listing/Columns/YellowCube.php
+++ b/Ui/Component/Listing/Columns/YellowCube.php
@@ -55,16 +55,20 @@ class YellowCube extends \Magento\Ui\Component\Listing\Columns\Column
                 $response = $item['yc_response'] ?? null;
 
                 $status = __('No');
+                $cssClass = '';
                 if ($sync) {
                     if ($reference) {
                         $status = __('Pending, Reference: %1', $reference);
                     } else {
                         $status = __('Yes');
+                        $cssClass = 'yellowcube-success';
                     }
                 } elseif ($response) {
                     $status = __('Error: %1', $response);
+                    $cssClass = 'yellowcube-error';
                 }
 
+                $item['fieldClass'] = $cssClass;
                 $item['yellowcube'] = $status;
             }
         }

--- a/view/adminhtml/ui_component/product_listing.xml
+++ b/view/adminhtml/ui_component/product_listing.xml
@@ -10,6 +10,7 @@
     <columns name="product_columns">
         <column name="yellowcube" class="\Swisspost\YellowCube\Ui\Component\Listing\Columns\YellowCube">
             <settings>
+                <bodyTmpl>Swisspost_YellowCube/ui/grid/cells/yellowcube</bodyTmpl>
                 <altField>name</altField>
                 <hasPreview>1</hasPreview>
                 <label translate="true">YellowCube</label>

--- a/view/base/web/template/ui/grid/cells/yellowcube.html
+++ b/view/base/web/template/ui/grid/cells/yellowcube.html
@@ -1,0 +1,1 @@
+<div data-bind="css: $row().fieldClass" text="$col.getLabel($row())"/>


### PR DESCRIPTION
Added a possibility to add a css class to the column cell bases on the
value defined in the element. The css classes in the Column class are
just an example and also a corresponding styles file should be added